### PR TITLE
Diagonale winconditie gefixt en game state toegevoegd aan game result.

### DIFF
--- a/src/TicTacToeSampleHttpClient/Engines/GamePlayerFirstChoice.cs
+++ b/src/TicTacToeSampleHttpClient/Engines/GamePlayerFirstChoice.cs
@@ -82,6 +82,13 @@ namespace TicTacToeSampleHttpClient.Engines
                         game = httpClient.DownloadString(apiUrl + string.Format("makeMove?boardColumn={0}&boardRow={1}&cellColumn={2}&cellRow={3}&playerId={4}",
                             currentMove.Item1, currentMove.Item2, currentMove.Item3, currentMove.Item4, playerId.ToString()));
 
+                        // If the length of game is 81, it only contains the game state.
+                        // If the length of game is 82, it contains the game state followed by the 'winner'.
+                        if (game.Length == 82)
+                        {
+                            game = game.Substring(81, 1);
+                        }
+
                         if (game.Equals("2", StringComparison.OrdinalIgnoreCase))
                         {
                             Console.WriteLine(Name + " has won a game! Yeah!");

--- a/src/TicTacToeSampleHttpClient/Engines/GamePlayerRandom.cs
+++ b/src/TicTacToeSampleHttpClient/Engines/GamePlayerRandom.cs
@@ -85,6 +85,13 @@ namespace TicTacToeSampleHttpClient.Engines
                         game = httpClient.DownloadString(apiUrl + string.Format("makeMove?boardColumn={0}&boardRow={1}&cellColumn={2}&cellRow={3}&playerId={4}",
                             currentMove.Item1, currentMove.Item2, currentMove.Item3, currentMove.Item4, playerId.ToString()));
 
+                        // If the length of game is 81, it only contains the game state.
+                        // If the length of game is 82, it contains the game state followed by the 'winner'.
+                        if (game.Length == 82)
+                        {
+                            game = game.Substring(81, 1);
+                        }
+
                         if (game.Equals("2", StringComparison.OrdinalIgnoreCase))
                         {
                             Console.WriteLine(Name + " has won a game! Yeah!");

--- a/src/TicTacToeSampleHttpClient/Engines/GamePlayerWinMoves.cs
+++ b/src/TicTacToeSampleHttpClient/Engines/GamePlayerWinMoves.cs
@@ -104,6 +104,13 @@ namespace TicTacToeSampleHttpClient.Engines
                         game = httpClient.DownloadString(apiUrl + string.Format("makeMove?boardColumn={0}&boardRow={1}&cellColumn={2}&cellRow={3}&playerId={4}",
                             currentMove.Item1, currentMove.Item2, currentMove.Item3, currentMove.Item4, playerId.ToString()));
 
+                        // If the length of game is 81, it only contains the game state.
+                        // If the length of game is 82, it contains the game state followed by the 'winner'.
+                        if (game.Length == 82)
+                        {
+                            game = game.Substring(81, 1);
+                        }
+
                         if (game.Equals("2", StringComparison.OrdinalIgnoreCase))
                         {
                             Console.WriteLine(Name + " has won a game! Yeah!");

--- a/src/TicTacToeServer/Controllers/GameController.cs
+++ b/src/TicTacToeServer/Controllers/GameController.cs
@@ -123,7 +123,7 @@ namespace TicTacToeServer.Controllers
                 return new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(playerState.CurrentGame.GameResult.ToString(CultureInfo.InvariantCulture), Encoding.UTF8, "text/plain")
+                    Content = new StringContent(playerState.CurrentGame.ToString() + playerState.CurrentGame.GameResult.ToString(CultureInfo.InvariantCulture), Encoding.UTF8, "text/plain")
                 };
             }
             catch (Exception ex)

--- a/src/TicTacToeServer/GameStateHelper.cs
+++ b/src/TicTacToeServer/GameStateHelper.cs
@@ -31,7 +31,7 @@ namespace TicTacToeServer
                 ServerGameState oldGameState;
                 Games.TryRemove(existingPlayer, out oldGameState);
 
-                Logger.Current.Info("New reaplcing player: {0}. He's taking on the boss... again", name);
+                Logger.Current.Info("New replacing player: {0}. He's taking on the boss... again", name);
             }
             else
             {

--- a/src/TicTacToeShared/SmallBoard.cs
+++ b/src/TicTacToeShared/SmallBoard.cs
@@ -115,7 +115,7 @@ namespace TicTacToeShared
             }
 
             //is Diagonal ?
-            if ((column + row) == 2)
+            if ((column + row) % 2 == 0)
             {
                 if ((cells[0, 0].Owner == player) && (cells[1, 1].Owner == player) && (cells[2, 2].Owner == player))
                 {


### PR DESCRIPTION
Ha Floris,

Hierbij mijn aanpassingen voor de TicTacToe server. Ik heb ook meteen de sample HTTP client engines aangepast aan de nieuwe situatie. En een typo gefixt ;)

In tegenstelling tot wat ik eerder mailde heb ik de game state voor het game result gezet omdat dit meer overeenkwam met de volgorde van handelingen: server doet een move waardoor het spel eindigt.

In de situatie waar het spel eindigt door een move van de tegenstander zou je eventueel de game state kunnen weglaten omdat er dan geen server move is, maar dan heb je weer meteen 3 verschillende lengtes van output (81, 82, 1)...
